### PR TITLE
Added custom folder and fragment ion support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist/
 *.svg
 !report.svg
 !tests/testdata/1AB-1001.mzML
+*.egg-info/

--- a/mscheck/analyse.py
+++ b/mscheck/analyse.py
@@ -139,13 +139,16 @@ class AnalyseSpectrum(MassSpectrum):
         else:
             return mass_ion, []
 
-    def analyse(self, compoundsmiles: str, ionstoadd: list, tolerance: int) -> dict:
+    def analyse(self, compoundsmiles: str, ionstoadd: list, tolerance: int, ionstosub: list = None) -> dict:
         """
         Performs analysis of spectrum
         Args:
             compoundsmiles (str): SMILES string for the target compound ebing analysed
             ionstoadd (list): list of ions as neutral SMILES to add to target compound mass for
                               searching mass spectrum eg. ["[H]", "[Na]"]
+            ionstosub (list): list of ions as neutral SMILES to remove from a target compound
+                              mass for searching mass spectrum 
+                              eg. ["CC(C)=C","O=C=O.CC(C)=C"] for -tBu and -Boc fragmentation
             tolerance (int): tolerance set for finding a match. Eg. tolerance set to 1 will
                              search for target compound with mass in spectrum of:
                              MW target compound plus/minus 1
@@ -161,7 +164,18 @@ class AnalyseSpectrum(MassSpectrum):
         ions_to_add_mols = [get_mol(ion) for ion in ionstoadd]
         ions_to_add_MW = [get_MW(mol) for mol in ions_to_add_mols]
 
-        for ion_to_add_mol, MW in zip(ions_to_add_mols, ions_to_add_MW):
+        if ionstosub:
+            ions_to_sub_mols = [get_mol(ion) for ion in ionstosub]
+            # Mass +1 to account for resultant +H adduct observed - assuming positive ionisation method
+            ions_to_sub_MW = [1 - get_MW(mol) for mol in ions_to_sub_mols]
+        else:
+            ions_to_sub_mols = []
+            ions_to_sub_MW = []
+        
+        ions_to_alter_mols = ions_to_add_mols + ions_to_sub_mols
+        ions_to_alter_MW = ions_to_add_MW + ions_to_sub_MW
+
+        for ion_to_alter_mol, MW in zip(ions_to_alter_mols, ions_to_alter_MW):
             parent_mass = MW + self.compound_MW
             test_ion_masses = [
                 parent_mass - tolerance,
@@ -173,7 +187,7 @@ class AnalyseSpectrum(MassSpectrum):
 
             for result in match_results:
                 if result[1]:
-                    ions_matched.append((get_smiles(ion_to_add_mol), result[0]))
+                    ions_matched.append((get_smiles(ion_to_alter_mol), result[0]))
                     RT_matched.append(self.MSpeakdata["RT"][result[1]])
                     TIC_matched.append(self.MSpeakdata["TIC"][result[1]])
                     mz_data_matched.append(
@@ -219,10 +233,13 @@ class AnalyseSpectrum(MassSpectrum):
         mz_intensities_max = mz_intensities[max_index]
         return mz_masses_max, mz_intensities_max, max_index
 
-    def create_report(self, compound_name: str = None) -> MassCheckReport:
+    def create_report(self, compound_name: str = None,
+                      folder:str = None) -> MassCheckReport:
         no_plots = len(self.Matchdata["ions"])
         if not compound_name:
             compound_name = get_path_leaf(self._filepath)
+        if not folder:
+            folder = "reports"
 
         create_report_plot(
             RT_values=self.MSdata["RT"],
@@ -231,4 +248,5 @@ class AnalyseSpectrum(MassSpectrum):
             mol=self.compound_mol,
             match_data=self.Matchdata,
             compound_name=compound_name,
+            folder=folder
         )

--- a/mscheck/report.py
+++ b/mscheck/report.py
@@ -35,7 +35,8 @@ pylab.rcParams.update(params)
 
 def create_report_dir(func):
     def wrapper(*args, **kwargs):
-        Path("../reports").mkdir(parents=True, exist_ok=True)
+        target_folder = kwargs["folder"]
+        Path("../{}".format(target_folder)).mkdir(parents=True, exist_ok=True)
         Path("../tmpimages").mkdir(parents=True, exist_ok=True)
         func(*args, **kwargs)
         shutil.rmtree("../tmpimages")
@@ -50,7 +51,8 @@ def create_report_plot(
     compound_name: str,
     no_plots: int,
     mol: rdkitmol,
-    match_data: dict = None,
+    folder: str,
+    match_data: dict = None
 ) -> plot:
     """
     Creates report
@@ -77,7 +79,8 @@ def create_report_plot(
             "40cm",
             SVG("../tmpimages/molecule.svg").scale(0.004).move(3, 3),
             SVG("../tmpimages/plot.svg").scale(0.03),
-        ).save("../reports/{}-report.svg".format(compound_name))
+        ).save("../{}/{}-report.svg".format(folder, compound_name))
+        plt.close('all')
 
     else:
         fig, ax = plt.subplots(no_plots + 1)
@@ -147,7 +150,7 @@ def create_report_plot(
             plt.setp(baseline, "color", "k")
 
             ax[subplot].set_title(
-                "Stongest mz pattern matching M + {} ({}) at RT: {} (min) ".format(
+                "Stongest mz pattern matching {} ion ({}) at RT: {} (min) ".format(
                     ion_name, ion_found[1], np.round(RT_max, 1)
                 )
             )
@@ -180,4 +183,5 @@ def create_report_plot(
             "40cm",
             SVG("../tmpimages/molecule.svg").scale(0.004).move(3, 3),
             SVG("../tmpimages/plot.svg").scale(0.03),
-        ).save("../reports/{}-report.svg".format(compound_name))
+        ).save("../{}/{}-report.svg".format(folder,compound_name))
+        plt.close('all')


### PR DESCRIPTION
Hi,

I found MScheck via your recent ChemRxiv publication (https://chemrxiv.org/engage/chemrxiv/article-details/641ef81e647e3dca997c2ba6) and have found this to be a really useful tool!

In using it, I found a few features I wanted to add, and so have done so in this branch:

- Added the choice of a custom output folder
- Added the functionality to search for fragmentation ions (e.g. the commonly observed McLafferty Boc fragmentation - resulting in -tBu and -Boc masses showing up). This also resulted in a minor change to the report title above the found MS ion chart(s)
- I also added a fix to close matplotlib figures after use (in our use case we are using MScheck in a loop for plate analysis, once the no. of figures exceeds 20 (i.e. ~20 analyses) a memory warning would show up in the terminal although the process would still complete).

Thanks for sharing this tool! 

Daniel